### PR TITLE
Add option to disable PRIMARY notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ it just exits when it changes. This is intentional -- X11's selection API is
 verging on the insane, and there are plenty of others who have already lost
 their sanity to bring us xclip/xsel/etc. Use one of those tools to complement
 clipnotify.
+
+## Options
+
+Option | Description
+--- | ---
+`-P`, `--disable-primary` | Do not notify on changes to PRIMARY (only to changes on clipboard)

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ clipnotify.
 
 Option | Description
 --- | ---
-`-P`, `--disable-primary` | Do not notify on changes to PRIMARY (only to changes on clipboard)
+`-P`, `--disable-primary` | Do not notify on changes to PRIMARY (only on changes to clipboard)

--- a/clipnotify.c
+++ b/clipnotify.c
@@ -3,12 +3,29 @@
 #include <X11/extensions/Xfixes.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
-int main(void) {
+int main(int argc, char **argv) {
     Display *disp;
     Window root;
     Atom clip;
     XEvent evt;
+
+    // Parse and validate flags
+    int disablePrimary = 0;
+    for (int i = 1; i < argc; i++) {
+        int disPrimary = (
+            strcmp(argv[i], "-P") == 0 || 
+            strcmp(argv[i], "--disable-primary") == 0
+        );
+
+        if (disPrimary) {
+            disablePrimary = 1;
+        } else {
+            fprintf(stderr, "Unrecognized option: %s\n", argv[i]);
+            exit(1);
+        }
+    }
 
     disp = XOpenDisplay(NULL);
     if (!disp) {
@@ -17,10 +34,12 @@ int main(void) {
     }
 
     root = DefaultRootWindow(disp);
-
     clip = XInternAtom(disp, "CLIPBOARD", False);
 
-    XFixesSelectSelectionInput(disp, root, XA_PRIMARY, XFixesSetSelectionOwnerNotifyMask);
+    if (!disablePrimary) {
+        XFixesSelectSelectionInput(disp, root, XA_PRIMARY, XFixesSetSelectionOwnerNotifyMask);
+    }
+
     XFixesSelectSelectionInput(disp, root, clip, XFixesSetSelectionOwnerNotifyMask);
 
     XNextEvent(disp, &evt);


### PR DESCRIPTION
This can cut down on unnecessary notifications for clipmenud when told not to handle PRIMARY.

See [this](https://github.com/cdown/clipmenu/pull/64).