### PR TITLE
add CFLAGS and LDFLAGS to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 all:
-	${CC} clipnotify.c -o clipnotify -lX11 -lXfixes
+	${CC} ${CFLAGS} ${LDFLAGS} clipnotify.c -o clipnotify -lX11 -lXfixes


### PR DESCRIPTION
The Makefile should respect any exported/given CFLAGS and LDFLAGS.

This PR adds those two flags to the ${CC} call.