### PR TITLE
Honor DESTDIR and PREFIX in {un,}install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
+PREFIX ?= /usr/local
+
 x11_bsd_flags = -I/usr/X11R6/include -L/usr/X11R6/lib
 
 all:
 	${CC} ${CFLAGS} ${LDFLAGS} clipnotify.c -o clipnotify $(x11_bsd_flags) -lX11 -lXfixes
 
 install: all
-	cp clipnotify /usr/local/bin
+	mkdir -p ${DESTDIR}${PREFIX}/bin
+	cp -f clipnotify ${DESTDIR}${PREFIX}/bin
+	chmod 755 ${DESTDIR}${PREFIX}/bin/clipnotify
 
 uninstall:
-	rm /usr/local/bin/clipnotify
+	rm -f ${DESTDIR}${PREFIX}/bin/clipnotify
 
 clean:
 	rm -f *.o *~ clipnotify


### PR DESCRIPTION
This should make `install' target usable on most package systems (that
could use DESTDIR and can possibly customize their PREFIX).