### PR TITLE
Continuous monitor mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,7 @@ clipnotify: clipnotify.c
 	${CC} ${CFLAGS} ${LDFLAGS} clipnotify.c -o clipnotify $(x11_bsd_flags) -lX11 -lXfixes
 
 install: all
-	mkdir -p ${DESTDIR}${PREFIX}/bin
-	cp -f clipnotify ${DESTDIR}${PREFIX}/bin
-	chmod 755 ${DESTDIR}${PREFIX}/bin/clipnotify
+	install -D -m755 clipnotify ${DESTDIR}${PREFIX}/bin
 
 uninstall:
 	rm -f ${DESTDIR}${PREFIX}/bin/clipnotify

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ PREFIX ?= /usr/local
 
 x11_bsd_flags = -I/usr/X11R6/include -L/usr/X11R6/lib
 
-all:
+all: clipnotify
+
+clipnotify: clipnotify.c
 	${CC} ${CFLAGS} ${LDFLAGS} clipnotify.c -o clipnotify $(x11_bsd_flags) -lX11 -lXfixes
 
 install: all

--- a/clipnotify.c
+++ b/clipnotify.c
@@ -30,6 +30,9 @@ int main(int argc, char **argv) {
     Atom clip;
     XEvent evt;
 
+    if (argc > 2)
+        fprintf(stderr, "Note: only first argument will be used - '%s'\n", argv[1]);
+
     disp = XOpenDisplay(NULL);
     if (!disp) {
         fprintf(stderr, "Can't open X display\n");

--- a/clipnotify.c
+++ b/clipnotify.c
@@ -3,8 +3,28 @@
 #include <X11/extensions/Xfixes.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <alloca.h>
 
-int main(void) {
+/* USE_FD - unix only, set aside stdout stream medium, using its file descriptor directly. */
+
+#ifdef USE_UNLOCKED_IO
+/* Nothing against this attempt, at least for now. */
+    #define f_fwrite fwrite_unlocked
+    #define f_fileno fileno_unlocked
+#else
+    #define f_fwrite fwrite
+    #define f_fileno fileno
+#endif
+
+#ifdef USE_ALLOCA
+/* At user's risk. Should be little to no problem in our case. */
+    #define f_alloc alloca
+#else
+    #define f_alloc malloc
+#endif
+
+int main(int argc, char **argv) {
     Display *disp;
     Window root;
     Atom clip;
@@ -24,5 +44,40 @@ int main(void) {
     XFixesSelectSelectionInput(disp, root, clip, XFixesSetSelectionOwnerNotifyMask);
 
     XNextEvent(disp, &evt);
+    if (argc) {
+        ////////////////////////////
+
+        //~ while (1) {
+            //~ printf ("%s\n", argv[1]);
+            //~ XNextEvent(disp, &evt);
+        //~ }
+
+        ////////////////////////////
+
+        //~ while (1) {
+            //~ dprintf (2, "%s\n", argv[1]);            
+            //~ XNextEvent(disp, &evt);
+        //~ }
+
+        ////////////////////////////
+
+        #ifdef USE_FD
+            int outd = f_fileno(stdout);
+        #endif
+
+        int s_len = strlen(argv[1]);
+        char *buf = f_alloc(s_len + 1);
+        memcpy(buf, argv[1], s_len);
+        buf[s_len++] = '\n';
+        while (1) {
+            #ifdef USE_FD
+                #include <unistd.h>
+                write(outd, buf, s_len);
+            #else
+                f_fwrite(buf, s_len, 1, stdout);
+            #endif
+            XNextEvent(disp, &evt);
+        }
+    }
     XCloseDisplay(disp);
 }

--- a/clipnotify.c
+++ b/clipnotify.c
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
     XFixesSelectSelectionInput(disp, root, clip, XFixesSetSelectionOwnerNotifyMask);
 
     XNextEvent(disp, &evt);
-    if (argc) {
+    if (argc > 1) {
         ////////////////////////////
 
         //~ while (1) {


### PR DESCRIPTION
I tried to implement persistent monitor daemon mode in simplest possible way (I guess it is). Without arguments act as usually. But if argument presents - enter mentioned monitor loop. Argument string is printed back on each clipboard change. This has little similarity to "yes" program, but besides being selective at when to print, it also uses only one argument - no concatenation is done. Argument "" should make it just a newline.

Now, instead of variant with shell loop, as in readme, more effective solutions could be used, e.g.:
```sh
stdbuf -oL clipnotify | awk '{...}'
stdbuf -oL clipnotify | sed -e '{e command' -e ';}'
(echo "command"; exec stdbuf -oL clipnotify) | sed -n -e '1{h;d;}; {g;e' -e ';}'
```

And as for user-supplied argument, it would allow more complex pipelines, where clipnotify has to crosstalk in parallel with other monitoring or notification tools, all in single shell block. E.g.:
```sh
( inotifywait --monitor --format 'filech:...' ... &
  pid=$?
  clipnotify clipch
  kill $pid
) | awk '
  /^clipch$/ {
    ...
  }
  /^filech:.../ {
    ...
  }'
```

NOTE: I tried various ways for text output, but all of them have drawbacks. So for now it has compile options, which may be passed via CFLAGS:

- USE_FD - use write() against fd 1 (which should be obtained from stdio stream), otherwise - regular fwriter. This effectively sets aside buffering issues, but could have problems due to being as simple as possible, and for now I did not try to handle even elementary issues, such as when write() call is interrupted by signal handler before can complete. Well, if there are default meaningful signal handlers.
- USE_UNLOCKED_IO - use unlocked thread-unsafe variants for whatever is used from stdio.h, if available of course (fileno_unlocked with USE_FD, fwrite_unlocked otherwise). I did not notice any source of threads, so assuming this should cause no problems,
- USE_ALLOCA - this is for argument string duplicate with newline replacing terminating null, for use with fwrite/write code variant (other variants - below). I know, this makes it to be placed in stack, and instead of being horrified just use with proper caution (no idea, if VLA better than this). Someone else would just use fixed-size array for buffer.

Also I have left commented out variants, using just `printf` and `dprintf`. I tried write just to avoid unneeded formating support. Could be just `fputs()`, but in fwrite I specify string length, which doesn't change through program run.

-----
So - for now I would like to know, if some options are redundant or useless, where single choice would suffice all cases,

Update: as for me, I use hardcoded `alloca`+`fwrite_unlocked` combo (in user patch, usable with gentoo package).

Fixes #16 