### PR TITLE
readme: Document valid clipmenu help flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ their sanity to bring us xclip/xsel/etc. Use one of those tools to complement
 clipnotify.
 
 You can choose a particular selection with `-s`, and loop instead of exiting
-with `-l`. See `clipmenu -h` for more information.
+with `-l`. See `clipmenu --help` for more information.


### PR DESCRIPTION
Switch to the long help flag because the short one is no longer valid.

ref: https://github.com/cdown/clipmenu/issues/142
